### PR TITLE
feat: Inclusão de Tipo de Conselho no Cadastro e Validações Integradas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,11 @@
 			<version>1.4.9</version>
 		</dependency>
 
-
+		<!-- Para Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
+++ b/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
@@ -32,10 +32,15 @@ public class AdviceBean extends Bean {
     }
 
     public void salvar() {
+        if (advice.getTipo() == null) {
+            addFaceMessage(FacesMessage.SEVERITY_ERROR, "Erro", "Selecione o Tipo de Conselho (Gratuito ou Pago).");
+            return;
+        }
+
         adviceService.save(advice);
         advices.add(advice);
         adicionarAdvice();
-        addFaceMessage(FacesMessage.SEVERITY_INFO, "Sucesso", null);
+        addFaceMessage(FacesMessage.SEVERITY_INFO, "Sucesso", "Conselho cadastrado com sucesso!");
     }
 
     public void gerar() {

--- a/src/main/java/com/example/hypeadvice/domain/entity/Advice.java
+++ b/src/main/java/com/example/hypeadvice/domain/entity/Advice.java
@@ -3,29 +3,41 @@ package com.example.hypeadvice.domain.entity;
 import com.google.gson.annotations.Expose;
 import lombok.Data;
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Data
 @javax.persistence.Entity
 @Table(name = "advice")
 public class Advice extends Entity {
+
     @Id
-    @Column(name = "ID", unique = true, nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID", unique = true, nullable = false)
     private Long id;
 
     @Expose
+    @NotBlank(message = "O nome é obrigatório.")
+    @Size(max = 100, message = "O nome deve ter no máximo 100 caracteres.")
     @Column(name = "NOME", length = 100)
     private String nome;
 
     @Expose
-    @Column(name = "DESCRICAO", columnDefinition = "TEXT", length = 1000, nullable = false)
+    @NotBlank(message = "A descrição é obrigatória.")
+    @Size(max = 100, message = "A descrição deve ter no máximo 100 caracteres.")
+    @Column(name = "DESCRICAO", columnDefinition = "TEXT", nullable = false)
     private String descricao;
+
+    @NotNull(message = "O tipo de conselho é obrigatório.")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "TIPO", nullable = false)
+    private TipoConselho tipo;
 
     public Advice(String adviceStr) {
         this.descricao = adviceStr;
     }
 
     public Advice() {
-
     }
 }

--- a/src/main/java/com/example/hypeadvice/domain/entity/TipoConselho.java
+++ b/src/main/java/com/example/hypeadvice/domain/entity/TipoConselho.java
@@ -1,0 +1,5 @@
+package com.example.hypeadvice.domain.entity;
+
+public enum TipoConselho {
+    GRATUITO, PAGO
+}

--- a/src/main/webapp/advice-crud.xhtml
+++ b/src/main/webapp/advice-crud.xhtml
@@ -22,32 +22,46 @@
 	<b:container>
 		<b:jumbotron>
 			<b:messages globalOnly="true" showSummary="true" redisplay="false" id="mensagensGlobais"/>
+
 			<h:form id="form-advice">
-				<b:form>
-					<b:inputText id="name" placeholder="Nome..." value="#{adviceBean.advice.nome}" label="Cadastrar Conselho"/>
-					<b:message for="@previous" />
+				<b:inputText id="name" placeholder="Nome..." value="#{adviceBean.advice.nome}" label="Cadastrar Conselho"/>
+				<b:message for="@previous" />
 
-					<b:inputTextarea placeholder="Descrição..." value="#{adviceBean.advice.descricao}" />
-					<b:message for="@previous" />
+				<b:inputTextarea placeholder="Nunca tome decisões com raiva ou medo..." value="#{adviceBean.advice.descricao}" label="Descrição"/>
+				<b:message for="@previous" />
 
-					<b:commandButton actionListener="#{adviceBean.salvar}"  update="form-advice form-advice-list mensagensGlobais" value="Salvar" />
-					<b:commandButton actionListener="#" look="info"  value="Gerar" >
-						<f:ajax onevent="click" listener="#{adviceBean.gerar}" render="form-advice"/>
-					</b:commandButton>
-				</b:form>
+				<b:selectOneMenu
+						value="#{adviceBean.advice.tipo}"
+						label="Tipo de Conselho"
+						id="tipoConselho"
+						required="true"
+						requiredMessage="Selecione um tipo de conselho.">
+
+					<f:selectItem itemLabel="Selecione..." itemValue="" noSelectionOption="true" />
+					<f:selectItem itemLabel="Gratuito" itemValue="GRATUITO" />
+					<f:selectItem itemLabel="Pago" itemValue="PAGO" />
+				</b:selectOneMenu>
+				<b:message for="tipoConselho" />
+
+				<b:commandButton actionListener="#{adviceBean.salvar}" update="form-advice form-advice-list mensagensGlobais" value="Salvar" />
+
+				<b:commandButton look="info" value="Gerar">
+					<f:ajax listener="#{adviceBean.gerar}" render="form-advice" />
+				</b:commandButton>
 			</h:form>
 		</b:jumbotron>
+
 		<b:jumbotron>
 			<h:form id="form-advice-list">
 				<h4 style="text-align:center">Conselhos Cadastrados</h4>
-				<b:dataTable value="#{adviceBean.advices}"
-							 var="advice">
+				<b:dataTable value="#{adviceBean.advices}" var="advice">
 					<b:dataTableColumn style="width:10%" value="#{advice.id}" />
 					<b:dataTableColumn value="#{advice.nome}" />
 					<b:dataTableColumn value="#{advice.descricao}" />
+					<b:dataTableColumn value="#{advice.tipo}" />
 					<b:dataTableColumn style="width:20%">
-						<b:commandButton actionListener="#"  look="warning" update="form-advice form-advice-list" value="Editar" />
-						<b:commandButton actionListener="#"  look="danger" update="form-advice form-advice-list" value="Excluir" />
+						<b:commandButton actionListener="#" look="warning" update="form-advice form-advice-list" value="Editar" />
+						<b:commandButton actionListener="#" look="danger" update="form-advice form-advice-list" value="Excluir" />
 					</b:dataTableColumn>
 				</b:dataTable>
 			</h:form>


### PR DESCRIPTION
# feat: Melhorias na Aplicação HypeAdvice – Exercício 2: Tipo de Conselho

## Objetivo

Aprimorar a interface e a funcionalidade do formulário de cadastro de conselhos, com foco em:

- Inclusão do tipo de conselho (Gratuito ou Pago) no momento da criação
- Validações obrigatórias no front-end e back-end
- Exibição adequada na listagem de conselhos
- Tratamento de erros com feedback direto ao usuário
- Melhoria geral da experiência e robustez da aplicação

## Alterações Realizadas

1. Alterado o cadastro de conselhos em `/advice-crud.xhtml` para permitir a seleção de "Tipo de Conselho" (Pago/Gratuito).
2. Incluída validação obrigatória que impede o cadastro de conselhos sem tipo definido.
3. Tabela de conselhos ajustada para exibir o tipo de forma clara e acessível.
4. Validações implementadas no backend (camada de serviço) para garantir integridade dos dados persistidos.

## Estrutura de Pacotes

| Pacote                                        | Descrição                                   |
|----------------------------------------------|---------------------------------------------|
| `com.example.hypeadvice.domain.entity`       | Entidades JPA: `Advice`, `TipoConselho`     |
| `com.example.hypeadvice.domain.bean`         | Managed Beans JSF                           |
| `com.example.hypeadvice.domain.service`      | Regras de negócio e validações              |
| `resources/META-INF/resources/advice.xhtml`  | Tela principal para cadastro e listagem     |
