### PR TITLE
 Implementação de Tipo de Conselho + Busca por ID via API externa (Exercícios 2 e 3 - HypeAdvice)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,18 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.konghq</groupId>
+			<artifactId>unirest-java</artifactId>
+			<version>3.13.6</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,11 @@
 			<version>1.4.9</version>
 		</dependency>
 
-
+		<!-- Para Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
+++ b/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
@@ -32,10 +32,15 @@ public class AdviceBean extends Bean {
     }
 
     public void salvar() {
+        if (advice.getTipo() == null) {
+            addFaceMessage(FacesMessage.SEVERITY_ERROR, "Erro", "Selecione o Tipo de Conselho (Gratuito ou Pago).");
+            return;
+        }
+
         adviceService.save(advice);
         advices.add(advice);
         adicionarAdvice();
-        addFaceMessage(FacesMessage.SEVERITY_INFO, "Sucesso", null);
+        addFaceMessage(FacesMessage.SEVERITY_INFO, "Sucesso", "Conselho cadastrado com sucesso!");
     }
 
     public void gerar() {

--- a/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
+++ b/src/main/java/com/example/hypeadvice/domain/bean/AdviceBean.java
@@ -2,33 +2,37 @@ package com.example.hypeadvice.domain.bean;
 
 import com.example.hypeadvice.domain.entity.Advice;
 import com.example.hypeadvice.domain.service.AdviceService;
+import com.example.hypeadvice.domain.vo.AdviceListVO;
+import com.example.hypeadvice.domain.vo.Slip;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ViewScoped;
+import javax.faces.context.FacesContext;
 import javax.inject.Named;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 @Named
 @ViewScoped
-public class AdviceBean extends Bean {
+public class AdviceBean extends Bean implements Serializable {
 
-    @Autowired AdviceService adviceService;
+    @Autowired
+    private AdviceService adviceService;
 
     private Advice advice = new Advice();
     private List<Advice> advices;
+    private AdviceListVO adviceListVO = new AdviceListVO();
+    private Integer id;
 
+    @PostConstruct
     public void initBean() {
         advices = adviceService.findAll();
-    }
-
-    public List<Advice> getAdvices() {
-        return advices;
-    }
-
-    public void setAdvices(List<Advice> advices) {
-        this.advices = advices;
     }
 
     public void salvar() {
@@ -40,6 +44,7 @@ public class AdviceBean extends Bean {
         adviceService.save(advice);
         advices.add(advice);
         adicionarAdvice();
+
         addFaceMessage(FacesMessage.SEVERITY_INFO, "Sucesso", "Conselho cadastrado com sucesso!");
     }
 
@@ -55,11 +60,71 @@ public class AdviceBean extends Bean {
         advice = new Advice();
     }
 
+    // Nova funcionalidade: busca de conselho por ID via API
+    public void buscarPorId() {
+        try {
+            Advice conselho = adviceService.buscarPorId(this.id);
+
+            if (conselho != null) {
+                Slip slip = new Slip();
+                slip.setId(conselho.getId());
+                slip.setAdvice(conselho.getDescricao());
+                slip.setDate(new Date());
+
+                List<Slip> slips = new ArrayList<>();
+                slips.add(slip);
+
+                adviceListVO.setSlips(slips);
+                adviceListVO.setTotal_results(1);
+                adviceListVO.setQuery(String.valueOf(id));
+
+                FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_INFO, "Conselho encontrado com sucesso!", null));
+            } else {
+                adviceListVO.setSlips(Collections.emptyList());
+                adviceListVO.setTotal_results(0);
+                FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_WARN, "Nenhum conselho encontrado para o ID informado.", null));
+            }
+
+        } catch (UnirestException e) {
+            adviceListVO.setSlips(Collections.emptyList());
+            adviceListVO.setTotal_results(0);
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Erro ao buscar conselho", e.getMessage()));
+        }
+    }
+
+    // Getters e Setters
     public Advice getAdvice() {
         return advice;
     }
 
     public void setAdvice(Advice advice) {
         this.advice = advice;
+    }
+
+    public List<Advice> getAdvices() {
+        return advices;
+    }
+
+    public void setAdvices(List<Advice> advices) {
+        this.advices = advices;
+    }
+
+    public AdviceListVO getAdviceListVO() {
+        return adviceListVO;
+    }
+
+    public void setAdviceListVO(AdviceListVO adviceListVO) {
+        this.adviceListVO = adviceListVO;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/example/hypeadvice/domain/bean/AdviceListBean.java
+++ b/src/main/java/com/example/hypeadvice/domain/bean/AdviceListBean.java
@@ -3,20 +3,29 @@ package com.example.hypeadvice.domain.bean;
 import com.example.hypeadvice.domain.entity.Advice;
 import com.example.hypeadvice.domain.service.AdviceService;
 import com.example.hypeadvice.domain.vo.AdviceListVO;
+import com.example.hypeadvice.domain.vo.Slip;
 import com.mashape.unirest.http.exceptions.UnirestException;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ViewScoped;
+import javax.faces.context.FacesContext;
+import javax.inject.Named;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.faces.bean.ViewScoped;
-import javax.inject.Named;
+import java.io.Serializable;
+import java.util.Collections;
 
 @Named
 @ViewScoped
-public class AdviceListBean extends Bean {
+public class AdviceListBean extends Bean implements Serializable {
 
-    @Autowired AdviceService adviceService;
+    @Autowired
+    private AdviceService adviceService;
 
     private Advice advice = new Advice();
     private AdviceListVO adviceListVO;
+    private Long idBusca;
+    private Advice conselhoPorId;
 
     public void initBean() {
         advice = new Advice();
@@ -30,6 +39,51 @@ public class AdviceListBean extends Bean {
         }
     }
 
+    public void buscarPorId() {
+        this.adviceListVO = new AdviceListVO(); // Limpa antes
+
+        try {
+            Advice conselho = adviceService.buscarPorId(idBusca.intValue());
+
+            if (conselho == null) {
+                FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_WARN, "Nenhum conselho encontrado para o ID informado.", null));
+                return;
+            }
+
+            Slip slip = new Slip();
+            slip.setId(conselho.getId());
+            slip.setAdvice(conselho.getDescricao());
+
+            AdviceListVO listVO = new AdviceListVO();
+            listVO.setSlips(Collections.singletonList(slip));
+            this.adviceListVO = listVO;
+
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Conselho encontrado com sucesso!", null));
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("Advice slip not found")) {
+                FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_INFO, "Nenhum conselho encontrado para o ID informado.", null));
+            } else {
+                e.printStackTrace();
+                FacesContext.getCurrentInstance().addMessage(null,
+                        new FacesMessage(FacesMessage.SEVERITY_ERROR, "Erro ao buscar conselho por ID.", null));
+            }
+        }
+    }
+
+    // Getters e Setters
+    public Advice getAdvice() {
+        return advice;
+    }
+
+    public void setAdvice(Advice advice) {
+        this.advice = advice;
+    }
+
     public AdviceListVO getAdviceListVO() {
         return adviceListVO;
     }
@@ -38,11 +92,19 @@ public class AdviceListBean extends Bean {
         this.adviceListVO = adviceListVO;
     }
 
-    public Advice getAdvice() {
-        return advice;
+    public Long getIdBusca() {
+        return idBusca;
     }
 
-    public void setAdvice(Advice advice) {
-        this.advice = advice;
+    public void setIdBusca(Long idBusca) {
+        this.idBusca = idBusca;
+    }
+
+    public Advice getConselhoPorId() {
+        return conselhoPorId;
+    }
+
+    public void setConselhoPorId(Advice conselhoPorId) {
+        this.conselhoPorId = conselhoPorId;
     }
 }

--- a/src/main/java/com/example/hypeadvice/domain/entity/Advice.java
+++ b/src/main/java/com/example/hypeadvice/domain/entity/Advice.java
@@ -3,29 +3,41 @@ package com.example.hypeadvice.domain.entity;
 import com.google.gson.annotations.Expose;
 import lombok.Data;
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Data
 @javax.persistence.Entity
 @Table(name = "advice")
 public class Advice extends Entity {
+
     @Id
-    @Column(name = "ID", unique = true, nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID", unique = true, nullable = false)
     private Long id;
 
     @Expose
+    @NotBlank(message = "O nome é obrigatório.")
+    @Size(max = 100, message = "O nome deve ter no máximo 100 caracteres.")
     @Column(name = "NOME", length = 100)
     private String nome;
 
     @Expose
-    @Column(name = "DESCRICAO", columnDefinition = "TEXT", length = 1000, nullable = false)
+    @NotBlank(message = "A descrição é obrigatória.")
+    @Size(max = 100, message = "A descrição deve ter no máximo 100 caracteres.")
+    @Column(name = "DESCRICAO", columnDefinition = "TEXT", nullable = false)
     private String descricao;
+
+    @NotNull(message = "O tipo de conselho é obrigatório.")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "TIPO", nullable = false)
+    private TipoConselho tipo;
 
     public Advice(String adviceStr) {
         this.descricao = adviceStr;
     }
 
     public Advice() {
-
     }
 }

--- a/src/main/java/com/example/hypeadvice/domain/entity/TipoConselho.java
+++ b/src/main/java/com/example/hypeadvice/domain/entity/TipoConselho.java
@@ -1,0 +1,5 @@
+package com.example.hypeadvice.domain.entity;
+
+public enum TipoConselho {
+    GRATUITO, PAGO
+}

--- a/src/main/java/com/example/hypeadvice/domain/service/AdviceService.java
+++ b/src/main/java/com/example/hypeadvice/domain/service/AdviceService.java
@@ -3,8 +3,12 @@ package com.example.hypeadvice.domain.service;
 import com.example.hypeadvice.domain.entity.Advice;
 import com.example.hypeadvice.domain.repository.AdviceRepository;
 import com.example.hypeadvice.domain.vo.AdviceListVO;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +18,11 @@ import java.util.List;
 @Service
 public class AdviceService {
 
-    @Autowired public AdviceRepository adviceRepository;
-    @Autowired public AdvicesLIPService advicesLIPService;
+    @Autowired
+    public AdviceRepository adviceRepository;
+
+    @Autowired
+    public AdvicesLIPService advicesLIPService;
 
     @Transactional(rollbackFor = Exception.class)
     public Advice save(Advice analiseContrato) {
@@ -32,10 +39,36 @@ public class AdviceService {
     }
 
     public AdviceListVO buscar(Advice advice) throws UnirestException {
-      String descricao = advice.getDescricao();
-      if (StringUtils.isNotBlank(descricao)) {
-          return advicesLIPService.buscarByDescricao(descricao);
-      }
-      return null;
+        String descricao = advice.getDescricao();
+        if (StringUtils.isNotBlank(descricao)) {
+            return advicesLIPService.buscarByDescricao(descricao);
+        }
+        return null;
+    }
+
+    //  busca conselho por ID via API externa
+    public Advice buscarPorId(int id) throws UnirestException {
+        HttpResponse<JsonNode> response = Unirest.get("https://api.adviceslip.com/advice/" + id)
+                .header("accept", "application/json")
+                .asJson();
+
+        JSONObject responseBody = response.getBody().getObject();
+
+        if (responseBody.has("message")) {
+            JSONObject message = responseBody.getJSONObject("message");
+            String errorText = message.optString("text", "Erro desconhecido ao buscar conselho.");
+            throw new UnirestException("Conselho não encontrado para o ID: " + id + " - " + errorText);
+        }
+
+        JSONObject slip = responseBody.optJSONObject("slip");
+
+        if (slip == null) {
+            throw new UnirestException("Conselho não encontrado para o ID: " + id);
+        }
+
+        Advice advice = new Advice();
+        advice.setId((long) slip.getInt("id"));
+        advice.setDescricao(slip.getString("advice"));
+        return advice;
     }
 }

--- a/src/main/webapp/advice-crud.xhtml
+++ b/src/main/webapp/advice-crud.xhtml
@@ -22,32 +22,46 @@
 	<b:container>
 		<b:jumbotron>
 			<b:messages globalOnly="true" showSummary="true" redisplay="false" id="mensagensGlobais"/>
+
 			<h:form id="form-advice">
-				<b:form>
-					<b:inputText id="name" placeholder="Nome..." value="#{adviceBean.advice.nome}" label="Cadastrar Conselho"/>
-					<b:message for="@previous" />
+				<b:inputText id="name" placeholder="Nome..." value="#{adviceBean.advice.nome}" label="Cadastrar Conselho"/>
+				<b:message for="@previous" />
 
-					<b:inputTextarea placeholder="Descrição..." value="#{adviceBean.advice.descricao}" />
-					<b:message for="@previous" />
+				<b:inputTextarea placeholder="Nunca tome decisões com raiva ou medo..." value="#{adviceBean.advice.descricao}" label="Descrição"/>
+				<b:message for="@previous" />
 
-					<b:commandButton actionListener="#{adviceBean.salvar}"  update="form-advice form-advice-list mensagensGlobais" value="Salvar" />
-					<b:commandButton actionListener="#" look="info"  value="Gerar" >
-						<f:ajax onevent="click" listener="#{adviceBean.gerar}" render="form-advice"/>
-					</b:commandButton>
-				</b:form>
+				<b:selectOneMenu
+						value="#{adviceBean.advice.tipo}"
+						label="Tipo de Conselho"
+						id="tipoConselho"
+						required="true"
+						requiredMessage="Selecione um tipo de conselho.">
+
+					<f:selectItem itemLabel="Selecione..." itemValue="" noSelectionOption="true" />
+					<f:selectItem itemLabel="Gratuito" itemValue="GRATUITO" />
+					<f:selectItem itemLabel="Pago" itemValue="PAGO" />
+				</b:selectOneMenu>
+				<b:message for="tipoConselho" />
+
+				<b:commandButton actionListener="#{adviceBean.salvar}" update="form-advice form-advice-list mensagensGlobais" value="Salvar" />
+
+				<b:commandButton look="info" value="Gerar">
+					<f:ajax listener="#{adviceBean.gerar}" render="form-advice" />
+				</b:commandButton>
 			</h:form>
 		</b:jumbotron>
+
 		<b:jumbotron>
 			<h:form id="form-advice-list">
 				<h4 style="text-align:center">Conselhos Cadastrados</h4>
-				<b:dataTable value="#{adviceBean.advices}"
-							 var="advice">
+				<b:dataTable value="#{adviceBean.advices}" var="advice">
 					<b:dataTableColumn style="width:10%" value="#{advice.id}" />
 					<b:dataTableColumn value="#{advice.nome}" />
 					<b:dataTableColumn value="#{advice.descricao}" />
+					<b:dataTableColumn value="#{advice.tipo}" />
 					<b:dataTableColumn style="width:20%">
-						<b:commandButton actionListener="#"  look="warning" update="form-advice form-advice-list" value="Editar" />
-						<b:commandButton actionListener="#"  look="danger" update="form-advice form-advice-list" value="Excluir" />
+						<b:commandButton actionListener="#" look="warning" update="form-advice form-advice-list" value="Editar" />
+						<b:commandButton actionListener="#" look="danger" update="form-advice form-advice-list" value="Excluir" />
 					</b:dataTableColumn>
 				</b:dataTable>
 			</h:form>

--- a/src/main/webapp/advice-list.xhtml
+++ b/src/main/webapp/advice-list.xhtml
@@ -2,47 +2,84 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
 	  xmlns:h="http://java.sun.com/jsf/html"
-
 	  xmlns:f="http://xmlns.jcp.org/jsf/core"
 	  xmlns:b="http://bootsfaces.net/ui">
+
 <f:metadata>
-	<f:viewAction action="#{adviceListBean.init}"/>
+	<f:viewAction action="#{adviceListBean.init}" />
 </f:metadata>
+
 <h:head>
-	<title>Hype Advice - Cadastro</title>
-	<meta name="author" content="The Author"></meta>
+	<title>Hype Advice - Consulta</title>
+	<meta name="author" content="Leonardo Oliveira" />
 </h:head>
+
 <h:body style="padding: 60px;">
+	<!-- Navbar -->
 	<b:navBar brand="Hype Advice" brandHref="#" fixed="top" inverse="true">
 		<b:navbarLinks>
-			<b:navLink value="Cadastro" href="http://localhost:8080/advice-crud.xhtml"></b:navLink>
-			<b:navLink value="Pesquisa" href="http://localhost:8080/advice-list.xhtml"></b:navLink>
+			<b:navLink value="Cadastro" href="http://localhost:8080/advice-crud.xhtml" />
+			<b:navLink value="Pesquisa" href="http://localhost:8080/advice-list.xhtml" />
 		</b:navbarLinks>
 	</b:navBar>
+
 	<b:container>
+
+		<!-- Mensagens -->
+		<b:messages globalOnly="true" showSummary="true" redisplay="false" id="mensagensGlobais" />
+
+		<!-- Pesquisa por Descrição -->
 		<b:jumbotron>
-			<b:messages globalOnly="true" showSummary="true" redisplay="false" id="mensagensGlobais"/>
 			<h:form id="form-advice">
 				<b:form>
-					<b:inputTextarea label="Pesquisar Conselho por Descrição" placeholder="Descrição..." value="#{adviceListBean.advice.descricao}" />
+					<b:inputTextarea label="Pesquisar Conselho por Descrição"
+									 placeholder="Digite parte do conselho..."
+									 value="#{adviceListBean.advice.descricao}" />
 					<b:message for="@previous" />
-
-					<b:commandButton actionListener="#{adviceListBean.buscar}" look="info"  update="form-advice-list mensagensGlobais" value="Buscar" >
-					</b:commandButton>
+					<b:commandButton actionListener="#{adviceListBean.buscar}"
+									 look="info"
+									 update="form-advice-list mensagensGlobais"
+									 value="Buscar" />
 				</b:form>
 			</h:form>
 		</b:jumbotron>
+
+		<!-- Pesquisa por ID -->
+		<b:jumbotron>
+			<h:form id="form-advice-id">
+				<b:form>
+					<b:inputText label="Pesquisar Conselho por ID"
+								 placeholder="Ex: 117"
+								 value="#{adviceListBean.idBusca}"
+								 type="number"
+								 min="1"
+								 required="true"
+								 requiredMessage="Informe um ID válido." />
+					<b:message for="@previous" />
+					<b:commandButton actionListener="#{adviceListBean.buscarPorId}"
+									 look="primary"
+									 value="Buscar por ID"
+									 update="form-advice-id form-advice-list mensagensGlobais" />
+				</b:form>
+			</h:form>
+		</b:jumbotron>
+
+		<!-- Resultado em Tabela -->
 		<b:jumbotron>
 			<h:form id="form-advice-list">
 				<h4 style="text-align:center">Conselhos Localizados</h4>
-				<b:dataTable value="#{adviceListBean.adviceListVO.slips}"
-							 var="advice">
-					<b:dataTableColumn style="width:10%" value="#{advice.id}" />
-					<b:dataTableColumn value="#{advice.advice}" />
-					<b:dataTableColumn value="#{advice.date}" />
+				<b:dataTable value="#{adviceListBean.adviceListVO.slips}" var="slip">
+					<b:dataTableColumn label="ID" value="#{slip.id}" style="width:10%" />
+					<b:dataTableColumn label="Conselho" value="#{slip.advice}" />
+					<b:dataTableColumn label="Data">
+						<h:outputText value="#{slip.date}">
+							<f:convertDateTime pattern="dd/MM/yyyy HH:mm:ss" />
+						</h:outputText>
+					</b:dataTableColumn>
 				</b:dataTable>
 			</h:form>
 		</b:jumbotron>
+
 	</b:container>
 </h:body>
 </html>


### PR DESCRIPTION
#  Implementação de Tipo de Conselho e Busca por ID via API externa na HypeAdvice

##  Descrição do Pull Request

Este PR integra as funcionalidades dos Exercícios 2 e 3 da aplicação **HypeAdvice**, com foco em melhorias de usabilidade, validações e consumo de API externa.

---

##  Funcionalidades Implementadas

###  Exercício 2 – Cadastro com Tipo de Conselho

- Adicionado campo de seleção (`Gratuito` ou `Pago`) no formulário de cadastro de conselhos (`advice-crud.xhtml`)
- Validação obrigatória no backend para impedir cadastro sem definição do tipo
- Exibição do tipo de conselho na listagem
- Atualização do método `salvar()` com verificação do tipo
- Refatoração para reaproveitamento de instância após salvar

---

###  Exercício 3 – Consumo de API Rest (Melhoria)

- Adicionado campo numérico para **busca de conselho por ID** via `https://api.adviceslip.com/advice/{id}`
- Método `buscarPorId()` implementado no `AdviceBean`
- Resposta da API convertida para VO interno (`AdviceListVO` com lista de `Slip`)
- Exibição em tela do conselho retornado, com validações e mensagens contextuais (sucesso/erro/ID inexistente)
- Tratamento para resposta `message` da API e mensagens de erro apropriadas para o usuário

---

##  Refatorações e Ajustes

- Otimização dos métodos `AdviceService.buscarPorId()` e `AdviceBean.salvar()`
- Unificação da exibição de mensagens JSF usando `FacesContext`
- Criação e manipulação de objetos `AdviceListVO` e `Slip` diretamente no bean
- Padronização de mensagens de feedback ao usuário

---

##  Observações

- As duas funcionalidades estão implementadas e testadas na mesma branch, evitando conflitos de código e facilitando a evolução da aplicação
- A tela `advice-crud.xhtml` continua funcional e agora com validações mais robustas
- A tela `advice-list.xhtml` foi expandida para exibir conselhos consultados por ID

---
